### PR TITLE
Universally use product_id rather than prod_id. Fixes an inconsistency i...

### DIFF
--- a/dns323fw-tool
+++ b/dns323fw-tool
@@ -500,43 +500,43 @@ def mkdns323fw(args)
 	devices = {
 		'DNS-325' => {
 			:signature => 'DNS-325',
-			:prod_id   => 0,
+			:product_id   => 0,
 			:custom_id => 8,
 			:model_id  => 5
 		},
 		'DNS-323' => {
 			:signature => 'FrodoII',
-			:prod_id   => 7,
+			:product_id   => 7,
 			:custom_id => 1,
 			:model_id  => 1
 		},
 		'DNS-321' => {
 			:signature => 'Chopper',
-			:prod_id   => 10,
+			:product_id   => 10,
 			:custom_id => 1,
 			:model_id  => 1
 		},
 		'DNS-320' => {
 			:signature => 'DNS323D1',  # No, seriously...
-			:prod_id   => 0,
+			:product_id   => 0,
 			:custom_id => 8,
 			:model_id  => 7
 		},
 		'DNS-320B' => {
 			:signature => 'DNS320B',
-			:prod_id   => 0,
+			:product_id   => 0,
 			:custom_id => 8,
 			:model_id  => 12
 		},
 		'DNS-320L' => {
 			:signature => 'DNS320L',
-			:prod_id   => 0,
+			:product_id   => 0,
 			:custom_id => 8,
 			:model_id  => 11
 		},
 		'CH3SNAS' => {
 			:signature => 'FrodoII',
-			:prod_id   => 7,
+			:product_id   => 7,
 			:custom_id => 2,
 			:model_id  => 1
 		},
@@ -564,7 +564,7 @@ def mkdns323fw(args)
 	        String) { |o| optargs[:output] = o }
 	opts.on('-p PROD_ID', '--product-id PROD_ID',
 	        "The product ID to embed in the firmware image",
-	        Integer) { |p| optargs[:prod_id] = p }
+	        Integer) { |p| optargs[:product_id] = p }
 	opts.on('-c CUSTOM_ID', '--custom-id CUSTOM_ID',
 	        "The custom ID to embed in the firmware image",
 	        Integer) { |c| optargs[:custom_id] = c }
@@ -587,7 +587,7 @@ def mkdns323fw(args)
 		optargs.merge(devices[optargs.delete(:device)])
 	end
 
-	%w{kernel_file initrd_file output prod_id custom_id model_id}.each do |k|
+	%w{kernel_file initrd_file output product_id custom_id model_id}.each do |k|
 		if opts[k.to_sym].nil?
 			$stderr.puts "Missing required argument #{k}"
 			exit 1


### PR DESCRIPTION
Universally use product_id rather than prod_id. Fixes an inconsistency in the code.